### PR TITLE
Added support for null values to align with specification

### DIFF
--- a/src/LtiAdvantage/AssignmentGradeServices/Result.cs
+++ b/src/LtiAdvantage/AssignmentGradeServices/Result.cs
@@ -28,13 +28,13 @@ namespace LtiAdvantage.AssignmentGradeServices
         /// Maximum result score.
         /// </summary>
         [JsonProperty("resultMaximum")]
-        public double ResultMaximum { get; set; }
+        public double? ResultMaximum { get; set; }
 
         /// <summary>
         /// The line item result.
         /// </summary>
         [JsonProperty("resultScore")]
-        public double ResultScore { get; set; }
+        public double? ResultScore { get; set; }
 
         /// <summary>
         /// The line item.


### PR DESCRIPTION
According to the [specification](https://www.imsglobal.org/spec/lti-ags/v2p0/#resultscore), `resultScore` and `resultMaximum` can be null/empty.  This update changes those properties in the `Result` model to nullables in order to support that.  This is a prerequisite for [TFS-123946](http://tfs.panopto.local:8080/tfs/DefaultCollection/Panopto%20Current/_workitems/edit/123946) 